### PR TITLE
Fix command handler

### DIFF
--- a/src/events/commandHandler.ts
+++ b/src/events/commandHandler.ts
@@ -25,10 +25,10 @@ export const COMMAND_HANDLER: BotEvent = {
                 content: 'There was an error while executing this command!',
                 ephemeral: true,
             };
-            if (interaction.replied) {
-                await interaction.reply(reply);
-            } else {
+            if (interaction.replied || interaction.deferred) {
                 await interaction.editReply(reply);
+            } else {
+                await interaction.reply(reply);
             }
         }
     },

--- a/src/events/commandHandler.ts
+++ b/src/events/commandHandler.ts
@@ -21,10 +21,15 @@ export const COMMAND_HANDLER: BotEvent = {
             await command.execute(interaction);
         } catch (error) {
             console.error(error);
-            await interaction.reply({
+            const reply = {
                 content: 'There was an error while executing this command!',
                 ephemeral: true,
-            });
+            };
+            if (interaction.replied) {
+                await interaction.reply(reply);
+            } else {
+                await interaction.editReply(reply);
+            }
         }
     },
     once: false,


### PR DESCRIPTION
the COMMAND_HANDLER bot event crashes the program if there is an exception raised and the interac(tion was already replied (with interaction.reply or interaction.editReply)

This fix checks if the interaction is already replied then send an edit or a new reply